### PR TITLE
Issue/9 optarg value

### DIFF
--- a/example/header_override/main.c
+++ b/example/header_override/main.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-
 #include "parseropt.h"
 
 enum
@@ -24,10 +23,10 @@ int main(int argc, char *argv[])
     // setHeader("/", NULL);
     // setHeader(NULL, "@@");
 
-    int id;                     // Found option's ID. (PsrArgumentObject_t.id)
-    char optarg[PSR_BUF_SIZE];  // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is "".
-    int optind = 0;             // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
-    while((id = persoropt(argc, argv, options, optarg, &optind)) != PSR_NOT_FOUND)
+    int id;         // Found option's ID. (PsrArgumentObject_t.id)
+    char *optarg;   // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is NULL.
+    int optind = 0; // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
+    while((id = persoropt(argc, argv, options, &optarg, &optind)) != PSR_NOT_FOUND)
     {
         // find option
         switch (id)
@@ -41,8 +40,11 @@ int main(int argc, char *argv[])
         case ID_OPT_ARG:
             printf("Optional Argument Option: %s\n", optarg);
             break;
-        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR
-            printf("Invalid Argument\n");
+        case PSR_ERROR:
+            printf("Process error\n");
+            break;
+        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR_HAS_ARG
+            printf("Invalid Argument: %s\n", argv[optind]);
             return -1;
         }
     }

--- a/example/long_option/main.c
+++ b/example/long_option/main.c
@@ -18,10 +18,10 @@ int main(int argc, char *argv[])
         PSR_ARG_END
     };
 
-    int id;                     // Found option's ID. (PsrArgumentObject_t.id)
-    char optarg[PSR_BUF_SIZE];  // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is "".
-    int optind = 0;             // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
-    while((id = persoropt(argc, argv, options, optarg, &optind)) != PSR_NOT_FOUND)
+    int id;         // Found option's ID. (PsrArgumentObject_t.id)
+    char *optarg;   // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is NULL.
+    int optind = 0; // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
+    while((id = persoropt(argc, argv, options, &optarg, &optind)) != PSR_NOT_FOUND)
     {
         // find option
         switch (id)
@@ -35,8 +35,11 @@ int main(int argc, char *argv[])
         case ID_OPT_ARG:
             printf("Optional Argument Option: %s\n", optarg);
             break;
-        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR
-            printf("Invalid Argument (%d)\n", id);
+        case PSR_ERROR:
+            printf("Process error\n");
+            break;
+        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR_HAS_ARG
+            printf("Invalid Argument: %s\n", argv[optind]);
             return -1;
         }
     }

--- a/example/short_and_long_option/main.c
+++ b/example/short_and_long_option/main.c
@@ -18,10 +18,10 @@ int main(int argc, char *argv[])
         PSR_ARG_END
     };
 
-    int id;                     // Found option's ID. (PsrArgumentObject_t.id)
-    char optarg[PSR_BUF_SIZE];  // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is "".
-    int optind = 0;             // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
-    while((id = persoropt(argc, argv, options, optarg, &optind)) != PSR_NOT_FOUND)
+    int id;         // Found option's ID. (PsrArgumentObject_t.id)
+    char *optarg;   // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is NULL.
+    int optind = 0; // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
+    while((id = persoropt(argc, argv, options, &optarg, &optind)) != PSR_NOT_FOUND)
     {
         // find option
         switch (id)
@@ -35,8 +35,11 @@ int main(int argc, char *argv[])
         case ID_OPT_ARG:
             printf("Optional Argument Option: %s\n", optarg);
             break;
-        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR
-            printf("Invalid Argument\n");
+        case PSR_ERROR:
+            printf("Process error\n");
+            break;
+        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR_HAS_ARG
+            printf("Invalid Argument: %s\n", argv[optind]);
             return -1;
         }
     }

--- a/example/short_option/main.c
+++ b/example/short_option/main.c
@@ -18,10 +18,10 @@ int main(int argc, char *argv[])
         PSR_ARG_END
     };
 
-    int id;                     // Found option's ID. (PsrArgumentObject_t.id)
-    char optarg[PSR_BUF_SIZE];  // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is "".
-    int optind = 0;             // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
-    while((id = persoropt(argc, argv, options, optarg, &optind)) != PSR_NOT_FOUND)
+    int id;         // Found option's ID. (PsrArgumentObject_t.id)
+    char *optarg;   // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is NULL.
+    int optind = 0; // Start index of non-option arguments (after calling persoropt() function). You must be set 0 or 1.
+    while((id = persoropt(argc, argv, options, &optarg, &optind)) != PSR_NOT_FOUND)
     {
         // find option
         switch (id)
@@ -35,8 +35,11 @@ int main(int argc, char *argv[])
         case ID_OPT_ARG:
             printf("Optional Argument Option: %s\n", optarg);
             break;
-        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR
-            printf("Invalid Argument\n");
+        case PSR_ERROR:
+            printf("Process error\n");
+            break;
+        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR_HAS_ARG
+            printf("Invalid Argument: %s\n", argv[optind]);
             return -1;
         }
     }

--- a/include/parseropt.h
+++ b/include/parseropt.h
@@ -37,6 +37,7 @@ extern "C" {
 #define PSR_REQ_ARG_HAS_NO_ARG  -4
 #define PSR_OPT_ARG_HAS_ONLY_EQ -5
 #define PSR_ERROR               -10
+#define PSR_ERROR_HAS_ARG       -11
 
 // types --------------------
 
@@ -65,7 +66,7 @@ int persoropt(
     int   argc                        ,
     char  **argv                      ,
     const PsrArgumentObject_t *options,
-    char  optarg[PSR_BUF_SIZE]        ,
+    char  **optarg                    ,
     int   *optind
 );
 


### PR DESCRIPTION
## Highlight
- optargにargv内のアドレスを返すように変更
- 上記変更により、`REQUIRE_ARGUMENT`と`OPTIONAL_ARGUMENT`のオプション引数の最大長が512から無制限（正式にはシステムがサポートする長さの上限）に上昇
- [example](https://github.com/GrapeJuicer/libparseropt/tree/release-v1.1.0/example)のコードが#9と#10の変更に対応
**Warning: `parseropt`関数の引数の型が変更されています**