### PR TITLE
issue/15 help message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ example/*/*
 !example/*/*.h
 !example/*/Makefile
 !example/*/make.bat
+!example/help_autowidth/termsz

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "files.encoding": "shiftjis"
     },
     "files.associations": {
-        "parseropt.h": "c"
+        "parseropt.h": "c",
+        "termsz.h": "c"
     }
 }

--- a/example/help/main.c
+++ b/example/help/main.c
@@ -27,14 +27,14 @@ int main(int argc, char *argv[])
     };
 
     PsrDescription_t descs[] = {
-        {.id = ID_HELP      , .desc = "Help option."                   },
-        {.id = ID_HELP      , .desc = "Help option with Custom config."},
-        {.id = ID_NO_ARG    , .desc = NULL                             }, // not shown
-        {.id = ID_REQ_ARG   , .desc = "Require argument."              },
-        {.id = ID_OPT_ARG   , .desc = "Optional argument."             },
-        {.id = ID_SHORT_ONLY, .desc = "Short option only."             },
-    //  {.id = ID_LONG_ONLY , .desc = "Long option only."              }, // not shown
-        {.id = 999999       , .desc = "Unknown."                       }, // not used
+        {.id = ID_HELP      , .desc = "Help option."                           },
+        {.id = ID_HELP      , .desc = "Help option with Custom config."        },
+        {.id = ID_NO_ARG    , .desc = NULL                                     }, // not shown
+        {.id = ID_REQ_ARG   , .desc = "Require argument.\nYou can use \'\\n\'."},
+        {.id = ID_OPT_ARG   , .desc = "Optional argument."                     },
+        {.id = ID_SHORT_ONLY, .desc = "Short option only."                     },
+    //  {.id = ID_LONG_ONLY , .desc = "Long option only."                      }, // not shown
+        {.id = 999999       , .desc = "Unknown."                               }, // not used
         PSR_DESC_END
     };
 

--- a/example/help/main.c
+++ b/example/help/main.c
@@ -27,14 +27,14 @@ int main(int argc, char *argv[])
     };
 
     PsrDescription_t descs[] = {
-        {.id = ID_HELP      , .desc = "Help option."                           },
-        {.id = ID_HELP      , .desc = "Help option with Custom config."        },
-        {.id = ID_NO_ARG    , .desc = NULL                                     }, // not shown
+        {.id = ID_HELP      , .desc = "Help option."},
+        {.id = ID_HELP      , .desc = "Help option with Custom config."},
+        {.id = ID_NO_ARG    , .desc = NULL}, // not shown
         {.id = ID_REQ_ARG   , .desc = "Require argument.\nYou can use \'\\n\'."},
-        {.id = ID_OPT_ARG   , .desc = "Optional argument."                     },
-        {.id = ID_SHORT_ONLY, .desc = "Short option only."                     },
-    //  {.id = ID_LONG_ONLY , .desc = "Long option only."                      }, // not shown
-        {.id = 999999       , .desc = "Unknown."                               }, // not used
+        {.id = ID_OPT_ARG   , .desc = "Optional argument."},
+        {.id = ID_SHORT_ONLY, .desc = "Short option only. this description is long long long long long long long long long long looooooooooooooooooong."},
+    //  {.id = ID_LONG_ONLY , .desc = "Long option only."}, // not shown
+        {.id = 999999       , .desc = "Unknown."}, // not used
         PSR_DESC_END
     };
 

--- a/example/help_autowidth/Makefile
+++ b/example/help_autowidth/Makefile
@@ -1,0 +1,7 @@
+TARGET = help
+
+all:
+	gcc main.c -I../../include -L../.. -lparseropt -o $(TARGET)
+
+clean:
+	rm $(TARGET)

--- a/example/help_autowidth/main.c
+++ b/example/help_autowidth/main.c
@@ -1,0 +1,110 @@
+#include <stdio.h>
+
+#include "termsz/termsz.h"
+#include "parseropt.h"
+
+enum
+{
+    ID_HELP,
+    ID_HELP2,
+    ID_NO_ARG,
+    ID_REQ_ARG,
+    ID_OPT_ARG,
+    ID_SHORT_ONLY,
+    ID_LONG_ONLY,
+};
+
+int main(int argc, char *argv[])
+{
+    // declare options
+    PsrArgumentObject_t options[] = {
+        {.id = ID_HELP      , .short_opt = 'h'           , .long_opt = "help"       , .has_arg = NO_ARGUMENT      , .priority = NONE_PRIORITY, .callfunc = NONE_CALLFUNC},
+        {.id = ID_HELP2     , .short_opt = 'H'           , .long_opt = "help2"      , .has_arg = NO_ARGUMENT      , .priority = NONE_PRIORITY, .callfunc = NONE_CALLFUNC},
+        {.id = ID_NO_ARG    , .short_opt = 'n'           , .long_opt = "no"         , .has_arg = NO_ARGUMENT      , .priority = NONE_PRIORITY, .callfunc = NONE_CALLFUNC},
+        {.id = ID_REQ_ARG   , .short_opt = 'r'           , .long_opt = "require"    , .has_arg = REQUIRE_ARGUMENT , .priority = NONE_PRIORITY, .callfunc = NONE_CALLFUNC},
+        {.id = ID_OPT_ARG   , .short_opt = 'o'           , .long_opt = "optional"   , .has_arg = OPTIONAL_ARGUMENT, .priority = NONE_PRIORITY, .callfunc = NONE_CALLFUNC},
+        {.id = ID_SHORT_ONLY, .short_opt = 's'           , .long_opt = NONE_LONG_OPT, .has_arg = NO_ARGUMENT      , .priority = NONE_PRIORITY, .callfunc = NONE_CALLFUNC},
+        {.id = ID_LONG_ONLY , .short_opt = NONE_SHORT_OPT, .long_opt = "long"       , .has_arg = NO_ARGUMENT      , .priority = NONE_PRIORITY, .callfunc = NONE_CALLFUNC},
+        PSR_ARG_END
+    };
+
+    PsrDescription_t descs[] = {
+        {.id = ID_HELP      , .desc = "Help option."},
+        {.id = ID_HELP      , .desc = "Help option with Custom config."},
+        {.id = ID_NO_ARG    , .desc = NULL}, // not shown
+        {.id = ID_REQ_ARG   , .desc = "Require argument.\nYou can use \'\\n\'."},
+        {.id = ID_OPT_ARG   , .desc = "Optional argument."},
+        {.id = ID_SHORT_ONLY, .desc = "Short option only. this description is long long long long long long long long long long looooooooooooooooooong."},
+    //  {.id = ID_LONG_ONLY , .desc = "Long option only."}, // not shown
+        {.id = 999999       , .desc = "Unknown."}, // not used
+        PSR_DESC_END
+    };
+
+    PsrHelpConfig_t help_conf = {
+        .indent     = 2   ,
+        .sep        = ", ",
+        .margin     = 8   ,
+        .desc_width = 60  ,
+    };
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Use autowidth if there are two or more spaces to describe the options
+    int col;
+    if (getTerminalSize(NULL, &col) == 0)
+    {
+        int dw_tmp = col - psrHDescOptionWidth(options, &help_conf, NULL, NULL);
+        if (dw_tmp > 1)
+        {
+            help_conf.desc_width = dw_tmp;
+        }
+    }
+    /////////////////////////////////////////////////////////////////////////////
+
+    int id;         // Found option's ID. (PsrArgumentObject_t.id)
+    char *optarg;   // REQUIRE_ARGUMENT/OPTIONAL_ARGUMENT option's argument. if no argument is given, this values is NULL.
+    int optind = 0; // Start index of non-option arguments (after calling parseropt() function). You must be set 0 or 1.
+    while((id = parseropt(argc, argv, options, &optarg, &optind)) != PSR_NOT_FOUND)
+    {
+        // find option
+        switch (id)
+        {
+        case ID_HELP:
+            psrHelp(options, descs, "help [options...]", NULL, NULL);
+            return 0;
+        case ID_HELP2:
+            psrHelpWithConfig(options, descs, "help [options...]", "This is a prefix text.", "This is a suffix text.", &help_conf);
+            return 0;
+        case ID_NO_ARG:
+            printf("No Argument Option\n");
+            break;
+        case ID_REQ_ARG:
+            printf("Require Argument Option: %s\n", optarg);
+            break;
+        case ID_OPT_ARG:
+            printf("Optional Argument Option: %s\n", optarg);
+            break;
+        case ID_SHORT_ONLY:
+            printf("Short only.\n");
+            break;
+        case ID_LONG_ONLY:
+            printf("Long only.\n");
+            break;
+        case PSR_ERROR:
+            printf("Process error\n");
+            break;
+        default: // PSR_UNKNOWN_OPTION, PSR_NO_ARG_HAS_ARG, PSR_REQ_ARG_HAS_NO_ARG, PSR_ERROR_HAS_ARG
+            printf("Invalid Argument: %s\n", argv[optind]);
+            return -1;
+        }
+    }
+
+    printf("Remain arguments -----\n");
+    int i;
+    for (i = optind; i < argc; i++)
+    {
+        printf("\t%s\n", argv[i]);
+    }
+
+    return 0;
+}

--- a/example/help_autowidth/make.bat
+++ b/example/help_autowidth/make.bat
@@ -1,0 +1,3 @@
+@echo off
+
+gcc main.c -I../../include -L../.. -lparseropt -o help

--- a/example/help_autowidth/termsz/LICENSE
+++ b/example/help_autowidth/termsz/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 GrapeJuicer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/example/help_autowidth/termsz/README.md
+++ b/example/help_autowidth/termsz/README.md
@@ -1,0 +1,44 @@
+# termsz.h
+
+`termsz.h`はターミナルのサイズを取得するライブラリです。
+
+ヘッダ内にすべてのソースコードを含めているため、`termsz.h`をプロジェクトにコピーしてインクルードするだけで使用できます。
+
+## Env
+
+たぶんWindows/Mac/Linuxどれでも行けると思う。
+ダメなケースあったらIssue投げてください。
+
+## Usage
+
+1. Include `termsz.h`
+```c
+#include "termsz.h"
+```
+
+2. Call `getTerminalSize()`
+
+```c
+int row, col;
+int ret;
+ret = getTerminalSize(&row, &col);
+```
+
+3. All done !
+```
+ <------------------------------------------ col ------------------------------------------>
++-------------------------------------------------------------------------------------------+
+|grape@GrapeCenter:~$ gcc --version                                                         |  ^
+|gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0                                                  |  |
+|Copyright (C) 2021 Free Software Foundation, Inc.                                          |  |
+|This is free software; see the source for copying conditions.  There is NO                 |  |
+|warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                | row
+|                                                                                           |  |
+|grape@GrapeCenter:~$                                                                       |  |
+|grape@GrapeCenter:~$                                                                       |  |
+|grape@GrapeCenter:~$                                                                       |  V
++-------------------------------------------------------------------------------------------+
+```
+
+- Return value ... 0 : success / 1 : failed
+

--- a/example/help_autowidth/termsz/termsz.h
+++ b/example/help_autowidth/termsz/termsz.h
@@ -1,0 +1,96 @@
+/**
+ * To disable getTerminalSize(), write following code before include this file:
+ *      #define TSZ_SYS 0
+ **/
+
+#include <stdio.h>
+
+#ifndef __TERMSZ_H
+#define __TERMSZ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif // end of #ifdef __cplusplus
+
+// defines --------------------
+
+#define TSZ_SYS_UNKNOWN 0
+#define TSZ_SYS_WIN32   1
+#define TSZ_SYS_UNIX    2
+#define TSZ_SYS_MAC     3
+
+#ifndef TSZ_SYS
+#if defined _WIN32 || defined _WIN64 // Windows
+#define TSZ_SYS TSZ_SYS_WIN32
+#elif defined __unix__ || defined __unix // UNIX
+#define TSZ_SYS TSZ_SYS_UNIX
+#elif defined __APPLE__ || defined __MACH__ // Mac
+#define TSZ_SYS TSZ_SYS_MAC
+#else // unknown
+#define TSZ_SYS TSZ_SYS_UNKNOWN
+#endif
+#endif // end of #ifndef TSZ_SYS
+
+// includes --------------------
+
+#if TSZ_SYS == TSZ_SYS_WIN32
+#include <windows.h>
+#elif TSZ_SYS == TSZ_SYS_UNIX
+#include <sys/ioctl.h>
+#include <unistd.h>
+#elif TSZ_SYS == TSZ_SYS_MAC
+// no includes
+#endif
+
+// functions --------------------
+
+/**
+ * @brief Get teminal size.
+ * @param row Address of a variable to store the result of row. Nullable.
+ * @param col Address of a variable to store the result of col. Nullable.
+ * @return 0: success / 1: failed
+ **/
+static inline int getTerminalSize(int *row, int *col)
+{
+#if TSZ_SYS == TSZ_SYS_WIN32 // Windows
+    CONSOLE_SCREEN_BUFFER_INFO inf;
+    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &inf) == 0)
+    {
+        return 1; // failed
+    }
+    if (row != NULL)
+    {
+        *row = inf.srWindow.Bottom - inf.srWindow.Top + 1;
+    }
+    if (col != NULL)
+    {
+        *col = inf.srWindow.Right - inf.srWindow.Left + 1;
+    }
+#elif TSZ_SYS == TSZ_SYS_UNIX || TSZ_SYS == TSZ_SYS_MAC // UNIX, Mac
+    struct winsize w;
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w))
+    {
+        return 1; // failed
+    }
+    if (row != NULL)
+    {
+        *row = w.ws_row;
+    }
+    if (col != NULL)
+    {
+        *col = w.ws_col;
+    }
+#else // unknown system
+    // do nothing
+    (void)row;
+    (void)col;
+    return 1;
+#endif
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif // end of #ifdef __cplusplus
+
+#endif // end of ifndef __TERMSZ_H

--- a/include/parseropt.h
+++ b/include/parseropt.h
@@ -120,8 +120,15 @@ void psrHDescWithConfig(
 
 void psrHOptionNote(void);
 
-int isPsrArgumentEnd (
+int isPsrArgumentEnd(
     const PsrArgumentObject_t *options
+);
+
+int psrHDescOptionWidth(
+    const PsrArgumentObject_t *options,
+    const PsrHelpConfig_t *config,
+    int *swidth,
+    int *lwidth
 );
 
 // --------------------

--- a/src/help.c
+++ b/src/help.c
@@ -3,22 +3,37 @@
 #include <stdio.h>
 #include <string.h>
 
+// defines --------------------
+
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
+// variables --------------------
 
 const PsrHelpConfig_t DEFAULT_PSR_CONFIG = {
-    .indent     =  2,
-    .sep     =  ", ",
-    .margin     =  8,
-    .desc_width = 60,
+    .indent     =  2   ,
+    .sep        =  ", ",
+    .margin     =  8   ,
+    .desc_width = 60   ,
 };
 
+// prototype declarations --------------------
 
 int __isPsrDescEnd(const PsrDescription_t *desc);
+void __printHDescDescriotion(const char *s, int desc_indent);
 
+// functions --------------------
 
+/**
+ * @brief Print help message with config.
+ * @param options Option list.
+ * @param descs Description list.
+ * @param usage command usage: e.g. "command [options...] source target"
+ * @param prefix prifix text. Written before the description.
+ * @param prefix suffix text. Written at the end.
+ * @param config Help message config.
+ **/
 // usage, prefix, suffix is nullable
 void psrHelpWithConfig(const PsrArgumentObject_t *options, const PsrDescription_t *descs, const char *usage, const char *prefix, const char *suffix, const PsrHelpConfig_t *config)
 {
@@ -40,6 +55,9 @@ void psrHelpWithConfig(const PsrArgumentObject_t *options, const PsrDescription_
     // options
     psrHDescWithConfig(options, descs, config);
 
+    // note
+    psrHOptionNote();
+
     // suffix
     if (suffix != NULL)
     {
@@ -48,6 +66,12 @@ void psrHelpWithConfig(const PsrArgumentObject_t *options, const PsrDescription_
 }
 
 
+/**
+ * @brief Print description (help message item) with config.
+ * @param options Option list.
+ * @param descs Description list.
+ * @param config Help message config.
+ **/
 void psrHDescWithConfig(const PsrArgumentObject_t *options, const PsrDescription_t *descs, const PsrHelpConfig_t *config)
 {
     int swidth = 0;
@@ -56,6 +80,7 @@ void psrHDescWithConfig(const PsrArgumentObject_t *options, const PsrDescription
     const char *sep = config->sep;
     const unsigned int margin = config->margin;
     const unsigned int desc_width = config->desc_width;
+    int desc_total_indent;
 
     if (sep == NULL)
     {
@@ -117,6 +142,9 @@ void psrHDescWithConfig(const PsrArgumentObject_t *options, const PsrDescription
             }
         }
     }
+
+    // set desc indent size
+    desc_total_indent = indent + swidth + (swidth > 0 && lwidth > 0 ? strlen(sep) : 0) + lwidth + margin;
 
     for (int i = 0; isPsrArgumentEnd(&options[i]) == 0; i++)
     {
@@ -203,12 +231,35 @@ void psrHDescWithConfig(const PsrArgumentObject_t *options, const PsrDescription
         printf("%*s", margin, "");
 
         // description
-        //      future function: override '\n' to support newline in description.
-        printf("%s\n", descs[desc_idx].desc);
+        __printHDescDescriotion(descs[desc_idx].desc, desc_total_indent);
     }
 }
 
 
+/**
+ * @brief Print description.
+ * @param s Description string.
+ * @param desc_indent description indent size.
+ **/
+void __printHDescDescriotion(const char *s, int desc_indent)
+{
+    char *current = (char *)s;
+    char *next;
+
+    while ((next = strchr(current, '\n')) != NULL)
+    {
+        next++;
+        printf("%.*s%*s", (int)(next - current), current, desc_indent, "");
+        current = next;
+    }
+
+    printf("%s\n", current);
+}
+
+
+/**
+ * @brief Print note about option.
+ **/
 void psrHOptionNote(void)
 {
     printf("It is also possible to specify the options in the following:\n");

--- a/src/help.c
+++ b/src/help.c
@@ -57,6 +57,7 @@ void psrHelpWithConfig(const PsrArgumentObject_t *options, const PsrDescription_
     psrHDescWithConfig(options, descs, config);
 
     // note
+    printf("\n");
     psrHOptionNote();
 
     // suffix
@@ -75,17 +76,16 @@ void psrHelpWithConfig(const PsrArgumentObject_t *options, const PsrDescription_
  **/
 void psrHDescWithConfig(const PsrArgumentObject_t *options, const PsrDescription_t *descs, const PsrHelpConfig_t *config)
 {
-    int swidth = 0;
-    int lwidth = 0;
+    int swidth, lwidth, desc_total_indent;
     const unsigned int indent = config->indent;
     const char *sep = config->sep;
     const unsigned int margin = config->margin;
     const unsigned int desc_width = config->desc_width;
-    int desc_total_indent;
 
     if (sep == NULL)
     {
         // fail
+        fprintf(stderr, "Error: Failed to print description.\n");
         return;
     }
 
@@ -98,54 +98,11 @@ void psrHDescWithConfig(const PsrArgumentObject_t *options, const PsrDescription
     // header
     printf("Options:\n");
 
-    // calc width
-    for (int i = 0; isPsrArgumentEnd(&options[i]) == 0; i++)
+    if ((desc_total_indent = psrHDescOptionWidth(options, config, &swidth, &lwidth)) == -1)
     {
-        if (options[i].short_opt != NONE_SHORT_OPT)
-        {
-            // -a           ... no arg      2
-            // -b ARG       ... req arg     6
-            // -c[ARG]     ... opt arg     7
-            switch (options[i].has_arg)
-            {
-            case NO_ARGUMENT:
-                swidth = MAX(swidth, 2);
-                break;
-            case REQUIRE_ARGUMENT:
-                swidth = MAX(swidth, 6);
-                break;
-            case OPTIONAL_ARGUMENT:
-                swidth = MAX(swidth, 7);
-                break;
-            default:
-                return;
-            }
-        }
-        if (strcmp(options[i].long_opt, NONE_LONG_OPT))
-        {
-            // --alpha           ... no arg      n + 2
-            // --alpha ARG       ... req arg     n + 6
-            // --alpha=[ARG]     ... opt arg     n + 8
-            int tmp = strlen(options[i].long_opt);
-            switch (options[i].has_arg)
-            {
-            case NO_ARGUMENT:
-                lwidth = MAX(lwidth, tmp + 2);
-                break;
-            case REQUIRE_ARGUMENT:
-                lwidth = MAX(lwidth, tmp + 6);
-                break;
-            case OPTIONAL_ARGUMENT:
-                lwidth = MAX(lwidth, tmp + 8);
-                break;
-            default:
-                return;
-            }
-        }
+        fprintf(stderr, "Error: Failed to get option usage description width.\n");
+        return;
     }
-
-    // set desc indent size
-    desc_total_indent = indent + swidth + (swidth > 0 && lwidth > 0 ? strlen(sep) : 0) + lwidth + margin;
 
     for (int i = 0; isPsrArgumentEnd(&options[i]) == 0; i++)
     {
@@ -234,7 +191,7 @@ void psrHDescWithConfig(const PsrArgumentObject_t *options, const PsrDescription
         // description
         if (__printHDescDescriotion(descs[desc_idx].desc, desc_total_indent, config->desc_width))
         {
-            fprintf(stderr, "Error: Failed to print description.");
+            fprintf(stderr, "Error: Failed to print description.\n");
             return;
         }
     }
@@ -371,4 +328,86 @@ void psrHOptionNote(void)
 int __isPsrDescEnd(const PsrDescription_t *desc)
 {
     return (desc->id == NONE_ID && desc->desc == NONE_DESC) ? 1 : 0;
+}
+
+
+/**
+ * @brief Get option usage description width. See for more details on https://github.com/GrapeJuicer/libparseropt/wiki/psrHDescOptionWidth%E9%96%A2%E6%95%B0
+ * @param options Option list.
+ * @param config Help message config.
+ * @param swidth Short option usage description width.
+ * @param lwidth Long option usage description width.
+ * @return success(config==NULL): 0 / success(config!=NULL): total width / failed: -1
+ **/
+int psrHDescOptionWidth(const PsrArgumentObject_t *options, const PsrHelpConfig_t *config, int *swidth, int *lwidth)
+{
+    int _swidth = 0;
+    int _lwidth = 0;
+
+    // calc width
+    for (int i = 0; isPsrArgumentEnd(&options[i]) == 0; i++)
+    {
+        // swidth
+        if (options[i].short_opt != NONE_SHORT_OPT)
+        {
+            // -a           ... no arg      2
+            // -b ARG       ... req arg     6
+            // -c[ARG]      ... opt arg     7
+            switch (options[i].has_arg)
+            {
+            case NO_ARGUMENT:
+                _swidth = MAX(_swidth, 2);
+                break;
+            case REQUIRE_ARGUMENT:
+                _swidth = MAX(_swidth, 6);
+                break;
+            case OPTIONAL_ARGUMENT:
+                _swidth = MAX(_swidth, 7);
+                break;
+            default:
+                return -1;
+            }
+        }
+
+        // lwidth
+        if (strcmp(options[i].long_opt, NONE_LONG_OPT))
+        {
+            // --alpha           ... no arg      n + 2
+            // --alpha ARG       ... req arg     n + 6
+            // --alpha=[ARG]     ... opt arg     n + 8
+            int tmp = strlen(options[i].long_opt);
+            switch (options[i].has_arg)
+            {
+            case NO_ARGUMENT:
+                _lwidth = MAX(_lwidth, tmp + 2);
+                break;
+            case REQUIRE_ARGUMENT:
+                _lwidth = MAX(_lwidth, tmp + 6);
+                break;
+            case OPTIONAL_ARGUMENT:
+                _lwidth = MAX(_lwidth, tmp + 8);
+                break;
+            default:
+                return -1;
+            }
+        }
+    }
+
+    if (swidth != NULL)
+    {
+        *swidth = _swidth;
+    }
+
+    if (lwidth != NULL)
+    {
+        *lwidth = _lwidth;
+    }
+
+    // set desc indent size
+    if (config == NULL)
+    {
+        return 0;
+    }
+
+    return config->indent + _swidth + (_swidth > 0 && _lwidth > 0 ? strlen(config->sep) : 0) + _lwidth + config->margin;
 }


### PR DESCRIPTION
- Supported '\n' on help message description.
- Supported help message option descrion configs.
- added `psrHDescOptionWidth()`
  It means this library supported auto-width help message using [termsz.h](https://github.com/GrapeJuicer/termsz.h) .